### PR TITLE
squash undefined index error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -92,8 +92,7 @@ function barre_log_login_success() {
 
 //log the failed logins
 function barre_log_login_failure() {
-	barre_log_login_log2file( 'LOGIN FAILURE '. $_REQUEST['username'] );
-}
+	isset($_REQUEST['username']) ? barre_log_login_log2file( 'LOGIN FAILURE '. $_REQUEST['username'] ) : null;}
 
 //log the logoffs
 function barre_log_login_logoff() {


### PR DESCRIPTION
When logged out of YOURLS and a page loads that a user has no access to, YOURLS throws the 

> undefined index "username" 

error out. This simple patch kills that error.