### PR TITLE
squash undefined index error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -92,7 +92,7 @@ function barre_log_login_success() {
 
 //log the failed logins
 function barre_log_login_failure() {
-	barre_log_login_log2file( 'LOGIN FAILURE '. $_REQUEST['username'] );
+	if( null !== 'username' ) barre_log_login_log2file( 'LOGIN FAILURE '. $_REQUEST['username'] );
 }
 
 //log the logoffs


### PR DESCRIPTION
When logged out of YOURLS and a page loads that a user has no access to, YOURLS throws the

undefined index "username"
error out. This simple patch kills that error.